### PR TITLE
Authentication and keep logged in

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,11 @@ frontend
 │   │   └── AccountInfoEdit.jsx
 │   ├── AuthPage
 │   │   ├── RegisterForm.jsx
-│   │   └── LoginForm.jsx
+│   │   ├── LoginForm.jsx
+│   │   └── LoginRequest.jsx
+│   ├── PlanPage
+│   │   ├── JoinPlan.jsx
+│   │   └── ExtendPlan.jsx
 │   └── FaqPage
 │       ├── FaqPage.jsx
 │       └── Data.jsx
@@ -114,6 +118,8 @@ frontend
 │       │   └── FaqPpage
 │       │       └── faqStyle.js
 │       └── animal-cloud-adoption.js
+├── services
+│   └── auth.jsx
 └── public
     ├── animals
     │   └── ....jpg

--- a/frontend/components/AuthPage/LoginForm.jsx
+++ b/frontend/components/AuthPage/LoginForm.jsx
@@ -1,53 +1,45 @@
 import React, { useState, useEffect } from 'react';
+import { handleLogin, isLoggedIn, logout } from "@/services/auth"
 import { Box, Button, Link, Grid, Container, TextField, IconButton, InputAdornment } from '@mui/material';
 import { ThemeProvider } from '@mui/material/styles';
 import { Visibility, VisibilityOff } from '@mui/icons-material';
 import { title, plan, brownTheme } from "@/styles/jss/animal-cloud-adoption.js";
-// 登入註冊相關
-// import { useHistory } from 'react-router-dom';
-// import { useDispatch, useSelector } from 'react-redux';
-// 登入 action
-// import { login } from '@/actions/authActions';
 
 export default function LoginForm() {
-    const [showPassword, setShowPassword] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const handleShowPassword = () => {
+    setShowPassword(!showPassword);
+  };
 
-    // 登入與驗證相關
-    // const dispatch = useDispatch();
-    // const auth = useSelector((state) => state.auth);
-    // const history = useHistory();
-  
-    const handleShowPassword = () => {
-      setShowPassword(!showPassword);
-    };
-  
-    const handleSubmit = (event) => {
-      event.preventDefault();
-      const data = new FormData(event.currentTarget);
-      const account = data.get('account');
-      const password = data.get('password');
-  
-      if (!account || !password) {
-        // 使用者沒有填寫資料，發出警告 Alert
-        alert('請填寫帳號和密碼！');
-      } else {
-        // 登入 action
-        // dispatch(login(account, password));
+  // 登入與驗證相關
+  const [userAccount, setUserAccount] = useState({
+    username: '',
+    password: ''
+  });
+
+  const handleUpdate = event => {
+    setUserAccount({...userAccount, [event.target.name]: event.target.value})
+  }
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    const data = new FormData(event.currentTarget);
+    const username = data.get('username');
+    const password = data.get('password');
+    if (!username || !password) {
+      // 使用者沒有填寫資料，發出警告 Alert
+      alert('請填寫帳號和密碼！');
+    } else {
+      logout()
+      handleLogin(userAccount)
+      if (isLoggedIn()) {
+        // 導回首頁
         window.location.href = '/';
+      } else {
+        alert('帳號或密碼錯誤！');
       }
-    };
-
-    // 登入與驗證相關
-    // useEffect(() => {
-    //   if (auth.isAuthenticated) {
-    //     localStorage.setItem('id', auth.user.id);
-    //     localStorage.setItem('token', auth.token);
-    //     // 導回首頁
-    //     history.push('/');
-    //   } else if (auth.error) {
-    //     alert('帳號或密碼錯誤！');
-    //   }
-    // }, [auth.isAuthenticated, auth.token, auth.user.id, auth.error, history]);
+    }
+  };
 
   return (
     <ThemeProvider theme={brownTheme}>
@@ -63,51 +55,61 @@ export default function LoginForm() {
             <h2 style={title}>
             登入
             </h2>
-            <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
-            <TextField
-                margin="normal"
-                required
-                fullWidth
-                id="account"
-                label="帳號"
-                name="account"
-                autoComplete="account"
-                autoFocus
-            />
-            <TextField
-                margin="normal"
-                required
-                fullWidth
-                name="password"
-                label="密碼"
-                type={showPassword ? 'text' : 'password'}
-                id="password"
-                autoComplete="current-password"
-                InputProps={{
-                endAdornment: (
-                    <InputAdornment position="end">
-                    <IconButton onClick={handleShowPassword}>
-                        {showPassword ? <Visibility /> : <VisibilityOff />}
-                    </IconButton>
-                    </InputAdornment>
-                )
-                }}
-            />
-            <Button
-                type="submit"
-                fullWidth
-                variant="contained"
-                sx={{ mt: 3, mb: 2 }}
-            >
-                登入
-            </Button>
-            <Grid container>
-                <Grid item>
-                <Link href="/auth/register" variant="body2">
-                    還沒有帳號？點此註冊
-                </Link>
-                </Grid>
-            </Grid>
+            <Box 
+              component="form"
+              method="post"
+              onSubmit={event => {
+                handleSubmit(event)
+              }}
+              noValidate
+              sx={{ mt: 1 }}
+              >
+              <TextField
+                  margin="normal"
+                  required
+                  fullWidth
+                  id="username"
+                  label="帳號"
+                  name="username"
+                  autoComplete="username"
+                  autoFocus
+                  onChange={handleUpdate}
+              />
+              <TextField
+                  margin="normal"
+                  required
+                  fullWidth
+                  name="password"
+                  label="密碼"
+                  type={showPassword ? 'text' : 'password'}
+                  id="password"
+                  autoComplete="current-password"
+                  InputProps={{
+                  endAdornment: (
+                      <InputAdornment position="end">
+                      <IconButton onClick={handleShowPassword}>
+                          {showPassword ? <Visibility /> : <VisibilityOff />}
+                      </IconButton>
+                      </InputAdornment>
+                  )
+                  }}
+                  onChange={handleUpdate}
+              />
+              <Button
+                  type="submit"
+                  fullWidth
+                  variant="contained"
+                  sx={{ mt: 3, mb: 2 }}
+              >
+                  登入
+              </Button>
+              <Grid container>
+                  <Grid item>
+                  <Link href="/auth/register" variant="body2">
+                      還沒有帳號？點此註冊
+                  </Link>
+                  </Grid>
+              </Grid>
             </Box>
         </Box>
         </Container>

--- a/frontend/components/AuthPage/LoginRequest.jsx
+++ b/frontend/components/AuthPage/LoginRequest.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { ThemeProvider } from '@mui/material/styles';
+import { Box, Container, Link } from '@mui/material';
+import { title, brownTheme } from "@/styles/jss/animal-cloud-adoption.js";
+
+export default function LoginRequest() {
+  return (
+    <ThemeProvider theme={brownTheme}>
+        <Container component="main" maxWidth="xs">
+        <Box
+            sx={{
+            marginTop: 3,
+            alignItems: 'center',
+            marginBottom: 3
+            }}
+        >
+            <h2 style={title}>
+            請先
+            <Link href="/auth/login">登入</Link>
+            ！
+            </h2>
+        </Box>
+        </Container>
+    </ThemeProvider>
+  )
+}

--- a/frontend/components/PlanPage/ExtendPlan.jsx
+++ b/frontend/components/PlanPage/ExtendPlan.jsx
@@ -1,0 +1,188 @@
+import React, { useState, useEffect } from 'react';
+import { Box, Button, Link, Grid, Typography, Container, List, ListItem, ListItemText, ListItemSecondaryAction, FormControl, InputLabel, MenuItem, Select, Collapse} from '@mui/material';
+import { ThemeProvider } from '@mui/material/styles';
+import { title, plan, brownTheme } from "@/styles/jss/animal-cloud-adoption.js";
+import EditIcon from '@mui/icons-material/Edit';
+
+// GET 所有方案所有資訊 
+const options = [
+    { id: 1, label: '方案一', price: 100, duration: 1 },
+    { id: 2, label: '方案二', price: 270, duration: 3 },
+    { id: 3, label: '方案三', price: 550, duration: 6 },
+    { id: 4, label: '方案四', price: 1000, duration: 12 },
+];
+
+// GET 單一 User (所有)資訊
+const user = { id: 33, email: 'b08705037@ntu.edu.tw', anonymous: true};
+
+// GET 單一 Animal (所有)資訊
+const animal = { id: 22, name: '小黑'};
+
+// GET 單一 Animal 當前認養中方案詳細
+const record = { id: 77, status: '認養中', endDate: "2023/5/10", planType: 4};
+
+export default function ExtendPlan() {
+    // 選擇方案
+    const [selectedOption, setSelectedOption] = useState(null);
+    const [checked, setChecked] = React.useState(false);
+    const handleChange = (event) => {
+        setSelectedOption(event.target.value);
+        if (!selectedOption){
+        setChecked((prev) => !prev);
+        }
+    };
+
+    // 顯示當前方案
+    const getPlanTypeName = (planType) => {
+        switch (planType) {
+        case 1:
+            return '方案一';
+        case 2:
+            return '方案二';
+        case 3:
+            return '方案三';
+        case 4:
+            return '方案四';
+        default:
+            return '未知方案';
+        }
+    };
+
+    const handleSubmit = (event) => {
+        event.preventDefault();
+        const data = new FormData(event.currentTarget);
+        const plan = selectedOption;
+        
+        if (!selectedOption) {
+        // 使用者沒有選擇方案，發出警告 Alert
+        alert('請選擇方案！');
+        } else {
+        // 寄發email
+        alert('匯款通知信件已寄出！\n請至您的 email 確認信件，\n並於時間內完成匯款。');
+
+        // 計算方案起訖日期
+        const today = new Date(record.endDate);
+        const currentDate = today.toLocaleDateString();
+        const futureDate = new Date(today.getFullYear(), today.getMonth() + plan.duration, today.getDate());
+        const endDate = futureDate.toLocaleDateString();
+
+        // 回傳
+        console.log({
+            amount: plan.price,
+            donatePeriod: plan.duration,
+            startDate: currentDate,
+            endDate: endDate,
+            planId: plan.id,
+            accountId: user.id,
+            animalId: animal.id,
+        });
+
+        // 導向動物資訊頁面
+        window.location.href = '/animals/animalsInfo';
+        }
+        
+    };
+  return (
+    <ThemeProvider theme={brownTheme}>
+        <div style={plan}>
+            <Container component="main" maxWidth="xs">
+                <Box
+                sx={{
+                    marginTop: 8,
+                    alignItems: 'center',
+                    marginBottom: 8,
+                }}
+                >
+                <h2 style={title}>
+                    延長{animal.name}的認養計畫
+                </h2>
+                <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
+                    <List container spacing={2}>
+                        <ListItem>
+                            <ListItemText primary="帳號："/>
+                            <ListItemSecondaryAction>
+                                {user.id}
+                            </ListItemSecondaryAction>
+                        </ListItem>
+                        <ListItem>
+                            <ListItemText primary="認養動物收容編號："/>
+                            <ListItemSecondaryAction>
+                                {animal.id}
+                            </ListItemSecondaryAction>
+                        </ListItem>
+                        <ListItem>
+                            <ListItemText primary="捐款方式："/>
+                            <ListItemSecondaryAction>
+                                <div>
+                                    {user.anonymous ? (
+                                    <>匿名捐款 <Link href="/account/edit"><EditIcon sx={{ fontSize:14 }} /></Link></>
+                                    ) : (
+                                    <>具名捐款 <Link href="/account/edit"><EditIcon sx={{ fontSize:14 }} /></Link></>
+                                    )}
+                                </div>
+                            </ListItemSecondaryAction>
+                        </ListItem>
+                        <ListItem>
+                            <ListItemText primary="認養方案："/>
+                            <ListItemSecondaryAction>
+                            <FormControl sx={{minWidth: 100 }}>
+                                <InputLabel id="option-label">方案</InputLabel>
+                                <Select
+                                labelId="option-label"
+                                id="option"
+                                value={selectedOption}
+                                label="Option"
+                                onChange={handleChange}
+                                required
+                                >
+                                {options.map((option) => (
+                                    <MenuItem key={option.id} value={option}>
+                                    {option.label}
+                                    </MenuItem>
+                                ))}
+                                </Select>
+                            </FormControl>
+                            </ListItemSecondaryAction>
+                        </ListItem>
+                        <Collapse in={checked}>
+                            <ListItem sx={{ display: 'flex', justifyContent: 'center' }}>
+                            <Typography sx={{ m: 1, border: '1px solid gray', padding: '1rem', display: selectedOption ? 'block' : 'none' }} borderRadius="10px">
+                                認養金額: ${selectedOption ? selectedOption.price : 'none'}
+                                <br/>
+                                認養時長: {selectedOption ? selectedOption.duration : 'none'} 個月
+                                <br/>
+                                當前認養方案類型: {selectedOption ? getPlanTypeName(record.planType) : 'none'} 
+                                <br/>
+                                預計新認養方案開始日期: {selectedOption ? record.endDate : 'none'} 
+                            </Typography>
+                            </ListItem>
+                        </Collapse>
+                    </List>
+                    <Button
+                    type="submit"
+                    fullWidth
+                    variant="contained"
+                    sx={{ mt: 2, mb: 2 }}
+                    >
+                    延長認養計畫
+                    </Button>
+                    <Grid container justifyContent="center" sx={{ mt: 1 }}>
+                        <Grid item sx={{ textAlign: 'center' }}>
+                            點擊「延長認養計畫」後，<br />
+                            我們會將匯款資訊寄送至您的信箱，<br />
+                            請於 3 天內完成匯款。<br />
+                            等待審查完畢後，即可成功延長認養{animal.name}！<br />
+                        </Grid>
+                        <Grid item sx={{ textAlign: 'center', mt: 1 }}>
+                        <Link href="/faq">
+                            進一步了解認養流程
+                        </Link>
+                        </Grid>
+                    </Grid>
+                </Box>
+                </Box>
+            </Container>
+        </div>
+    </ThemeProvider>
+  )
+}

--- a/frontend/components/PlanPage/JoinPlan.jsx
+++ b/frontend/components/PlanPage/JoinPlan.jsx
@@ -1,0 +1,167 @@
+import React, { useState } from 'react';
+import { Box, Button, Link, Grid, Typography, Container, List, ListItem, ListItemText, ListItemSecondaryAction, FormControl, InputLabel, MenuItem, Select, Collapse} from '@mui/material';
+import { ThemeProvider } from '@mui/material/styles';
+import { getUser } from "@/services/auth";
+import { title, plan, brownTheme } from "@/styles/jss/animal-cloud-adoption.js";
+import EditIcon from '@mui/icons-material/Edit';
+
+// GET 所有方案所有資訊 
+const options = [
+    { id: 1, label: '方案一', price: 100, duration: 1 },
+    { id: 2, label: '方案二', price: 270, duration: 3 },
+    { id: 3, label: '方案三', price: 550, duration: 6 },
+    { id: 4, label: '方案四', price: 1000, duration: 12 },
+  ];
+  
+  // GET 單一 User (所有)資訊
+  const user = { id: 33, email: 'b08705037@ntu.edu.tw', anonymous: true};
+  
+  // GET 單一 Animal (所有)資訊
+  const animal = { id: 22, name: '小黑'};
+
+export default function JoinPlan() {
+  // 選擇方案
+  const [selectedOption, setSelectedOption] = useState(null);
+  const [checked, setChecked] = React.useState(false);
+  const handleChange = (event) => {
+      setSelectedOption(event.target.value);
+      if (!selectedOption){
+        setChecked((prev) => !prev);
+      }
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    const data = new FormData(event.currentTarget);
+    const plan = selectedOption;
+    
+    if (!selectedOption) {
+    // 使用者沒有選擇方案，發出警告 Alert
+    alert('請選擇方案！');
+    } else {
+    // 寄發email
+    alert('匯款通知信件已寄出！\n請至您的 email 確認信件，\n並於時間內完成匯款。');
+
+    // 計算方案起訖日期
+    const today = new Date();
+    const currentDate = today.toLocaleDateString();
+    const futureDate = new Date(today.getFullYear(), today.getMonth() + plan.duration, today.getDate());
+    const endDate = futureDate.toLocaleDateString();
+
+    // 回傳
+    console.log({
+        amount: plan.price,
+        donatePeriod: plan.duration,
+        startDate: currentDate,
+        endDate: endDate,
+        planId: plan.id,
+        accountId: user.id,
+        animalId: animal.id,
+    });
+
+    // 導向動物資訊頁面
+    window.location.href = '/animals/animalsInfo';
+    }
+  };
+
+
+  return (
+    <ThemeProvider theme={brownTheme}>
+        <div style={plan}>
+            <Container component="main" maxWidth="xs">
+                <Box
+                sx={{
+                    marginTop: 8,
+                    alignItems: 'center',
+                    marginBottom: 8
+                }}
+                >
+                <h2 style={title}>
+                    加入{animal.name}的認養計畫！
+                </h2>
+                <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
+                    <List container spacing={2}>
+                        <ListItem>
+                            <ListItemText primary="帳號："/>
+                            <ListItemSecondaryAction>
+                                {getUser().username}
+                            </ListItemSecondaryAction>
+                        </ListItem>
+                        <ListItem>
+                            <ListItemText primary="認養動物收容編號："/>
+                            <ListItemSecondaryAction>
+                                {animal.id}
+                            </ListItemSecondaryAction>
+                        </ListItem>
+                        <ListItem>
+                            <ListItemText primary="捐款方式："/>
+                            <ListItemSecondaryAction>
+                                <div>
+                                    {user.anonymous ? (
+                                    <>匿名捐款 <Link href="/account/edit"><EditIcon sx={{ fontSize:14 }} /></Link></>
+                                    ) : (
+                                    <>具名捐款 <Link href="/account/edit"><EditIcon sx={{ fontSize:14 }} /></Link></>
+                                    )}
+                                </div>
+                            </ListItemSecondaryAction>
+                        </ListItem>
+                        <ListItem>
+                            <ListItemText primary="認養方案："/>
+                            <ListItemSecondaryAction>
+                            <FormControl sx={{minWidth: 100 }}>
+                                <InputLabel id="option-label">方案</InputLabel>
+                                <Select
+                                labelId="option-label"
+                                id="option"
+                                value={selectedOption}
+                                label="Option"
+                                onChange={handleChange}
+                                required
+                                >
+                                {options.map((option) => (
+                                    <MenuItem key={option.id} value={option}>
+                                    {option.label}
+                                    </MenuItem>
+                                ))}
+                                </Select>
+                            </FormControl>
+                            </ListItemSecondaryAction>
+                        </ListItem>
+                        <Collapse in={checked}>
+                            <ListItem sx={{ display: 'flex', justifyContent: 'center' }}>
+                            <Typography sx={{ m: 1, border: '1px solid gray', padding: '1rem', display: selectedOption ? 'block' : 'none' }} borderRadius="10px">
+                                認養金額: ${selectedOption ? selectedOption.price : 'none'}
+                                <br/>
+                                認養時長: {selectedOption ? selectedOption.duration : 'none'} 個月
+                            </Typography>
+                            </ListItem>
+                        </Collapse>
+                    </List>
+                    <Button
+                    type="submit"
+                    fullWidth
+                    variant="contained"
+                    sx={{ mt: 2, mb: 2 }}
+                    >
+                    加入認養計畫
+                    </Button>
+                    <Grid container justifyContent="center" sx={{ mt: 1 }}>
+                        <Grid item sx={{ textAlign: 'center' }}>
+                            點擊「加入認養計畫」後，<br />
+                            我們會將匯款資訊寄送至您的信箱，<br />
+                            請於 3 天內完成匯款。<br />
+                            等待審查完畢後，即可成功認養{animal.name}！<br />
+                        </Grid>
+                        <Grid item sx={{ textAlign: 'center', mt: 1 }}>
+                        <Link href="/faq">
+                            進一步了解認養流程
+                        </Link>
+                        </Grid>
+                    </Grid>
+                </Box>
+                </Box>
+            </Container>
+        </div>
+    </ThemeProvider>
+  )
+}

--- a/frontend/pages/animals/extendAdopt.jsx
+++ b/frontend/pages/animals/extendAdopt.jsx
@@ -1,196 +1,29 @@
+import React, { useEffect, useState } from "react";
 import Layout from '@/components/Layout'
-import React, { useState, useEffect } from 'react';
-import { Box, Button, Link, Grid, Typography, Container, List, ListItem, ListItemText, ListItemSecondaryAction, FormControl, InputLabel, MenuItem, Select, Collapse} from '@mui/material';
-import { ThemeProvider } from '@mui/material/styles';
-import { title, plan, brownTheme } from "@/styles/jss/animal-cloud-adoption.js";
-import EditIcon from '@mui/icons-material/Edit';
+import ExtendPlan from "@/components/PlanPage/ExtendPlan"
+import { isLoggedIn } from "@/services/auth";
+import LoginRequest from "@/components/AuthPage/LoginRequest";
 
-// GET 所有方案所有資訊 
-const options = [
-    { id: 1, label: '方案一', price: 100, duration: 1 },
-    { id: 2, label: '方案二', price: 270, duration: 3 },
-    { id: 3, label: '方案三', price: 550, duration: 6 },
-    { id: 4, label: '方案四', price: 1000, duration: 12 },
-];
+export default function extendAdopt() {
+  const [isClient, setIsClient] = useState(false);
 
-// GET 單一 User (所有)資訊
-const user = { id: 33, email: 'b08705037@ntu.edu.tw', anonymous: true};
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
 
-// GET 單一 Animal (所有)資訊
-const animal = { id: 22, name: '小黑'};
-
-// GET 單一 Animal 當前認養中方案詳細
-const record = { id: 77, status: '認養中', endDate: "2023/5/10", planType: 4};
-
-export default function ExtendAdopt() {
-// 選擇方案
-const [selectedOption, setSelectedOption] = useState(null);
-const [checked, setChecked] = React.useState(false);
-const handleChange = (event) => {
-    setSelectedOption(event.target.value);
-    if (!selectedOption){
-      setChecked((prev) => !prev);
-    }
-};
-
-// 顯示當前方案
-const getPlanTypeName = (planType) => {
-    switch (planType) {
-    case 1:
-        return '方案一';
-    case 2:
-        return '方案二';
-    case 3:
-        return '方案三';
-    case 4:
-        return '方案四';
-    default:
-        return '未知方案';
-    }
-};
-
-const handleSubmit = (event) => {
-    event.preventDefault();
-    const data = new FormData(event.currentTarget);
-    const plan = selectedOption;
-    
-    if (!selectedOption) {
-    // 使用者沒有選擇方案，發出警告 Alert
-    alert('請選擇方案！');
-    } else {
-    // 寄發email
-    alert('匯款通知信件已寄出！\n請至您的 email 確認信件，\n並於時間內完成匯款。');
-
-    // 計算方案起訖日期
-    const today = new Date(record.endDate);
-    const currentDate = today.toLocaleDateString();
-    const futureDate = new Date(today.getFullYear(), today.getMonth() + plan.duration, today.getDate());
-    const endDate = futureDate.toLocaleDateString();
-
-    // 回傳
-    console.log({
-        amount: plan.price,
-        donatePeriod: plan.duration,
-        startDate: currentDate,
-        endDate: endDate,
-        planId: plan.id,
-        accountId: user.id,
-        animalId: animal.id,
-    });
-
-    // 導向動物資訊頁面
-    window.location.href = '/animals/animalsInfo';
-    }
-    
-};
-
-
-
-
-return (
-    <Layout>
-        <ThemeProvider theme={brownTheme}>
-            <div style={plan}>
-                <Container component="main" maxWidth="xs">
-                    <Box
-                    sx={{
-                        marginTop: 8,
-                        alignItems: 'center',
-                        marginBottom: 8,
-                    }}
-                    >
-                    <h2 style={title}>
-                        延長{animal.name}的認養計畫
-                    </h2>
-                    <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
-                        <List container spacing={2}>
-                            <ListItem>
-                                <ListItemText primary="帳號："/>
-                                <ListItemSecondaryAction>
-                                    {user.id}
-                                </ListItemSecondaryAction>
-                            </ListItem>
-                            <ListItem>
-                                <ListItemText primary="認養動物收容編號："/>
-                                <ListItemSecondaryAction>
-                                    {animal.id}
-                                </ListItemSecondaryAction>
-                            </ListItem>
-                            <ListItem>
-                                <ListItemText primary="捐款方式："/>
-                                <ListItemSecondaryAction>
-                                    <div>
-                                      {user.anonymous ? (
-                                        <>匿名捐款 <Link href="/account/edit"><EditIcon sx={{ fontSize:14 }} /></Link></>
-                                      ) : (
-                                        <>具名捐款 <Link href="/account/edit"><EditIcon sx={{ fontSize:14 }} /></Link></>
-                                      )}
-                                    </div>
-                                </ListItemSecondaryAction>
-                            </ListItem>
-                            <ListItem>
-                                <ListItemText primary="認養方案："/>
-                                <ListItemSecondaryAction>
-                                <FormControl sx={{minWidth: 100 }}>
-                                    <InputLabel id="option-label">方案</InputLabel>
-                                    <Select
-                                    labelId="option-label"
-                                    id="option"
-                                    value={selectedOption}
-                                    label="Option"
-                                    onChange={handleChange}
-                                    required
-                                    >
-                                    {options.map((option) => (
-                                        <MenuItem key={option.id} value={option}>
-                                        {option.label}
-                                        </MenuItem>
-                                    ))}
-                                    </Select>
-                                </FormControl>
-                                </ListItemSecondaryAction>
-                            </ListItem>
-                            <Collapse in={checked}>
-                              <ListItem sx={{ display: 'flex', justifyContent: 'center' }}>
-                              <Typography sx={{ m: 1, border: '1px solid gray', padding: '1rem', display: selectedOption ? 'block' : 'none' }} borderRadius="10px">
-                                  認養金額: ${selectedOption ? selectedOption.price : 'none'}
-                                  <br/>
-                                  認養時長: {selectedOption ? selectedOption.duration : 'none'} 個月
-                                  <br/>
-                                  當前認養方案類型: {selectedOption ? getPlanTypeName(record.planType) : 'none'} 
-                                  <br/>
-                                  預計新認養方案開始日期: {selectedOption ? record.endDate : 'none'} 
-                              </Typography>
-                              </ListItem>
-                            </Collapse>
-                        </List>
-                        <Button
-                        type="submit"
-                        fullWidth
-                        variant="contained"
-                        sx={{ mt: 2, mb: 2 }}
-                        >
-                        延長認養計畫
-                        </Button>
-                        <Grid container justifyContent="center" sx={{ mt: 1 }}>
-                          <Grid item sx={{ textAlign: 'center' }}>
-                              點擊「延長認養計畫」後，<br />
-                              我們會將匯款資訊寄送至您的信箱，<br />
-                              請於 3 天內完成匯款。<br />
-                              等待審查完畢後，即可成功延長認養{animal.name}！<br />
-                          </Grid>
-                          <Grid item sx={{ textAlign: 'center', mt: 1 }}>
-                            <Link href="/faq">
-                              進一步了解認養流程
-                            </Link>
-                          </Grid>
-                        </Grid>
-                    </Box>
-                    </Box>
-                </Container>
-            </div>
-        </ThemeProvider>
-    </Layout>
-
-);
+  return (
+    <div>
+      <Layout>
+        {isClient && (
+          <>
+            {isLoggedIn() ? (
+              <ExtendPlan />
+            ) : (
+              <LoginRequest/>
+            )}
+          </>
+        )}
+      </Layout>
+    </div>
+  );
 }

--- a/frontend/pages/animals/joinAdopt.jsx
+++ b/frontend/pages/animals/joinAdopt.jsx
@@ -1,168 +1,29 @@
-import Layout from '@/components/Layout'
-import React, { useState } from 'react';
-import { Box, Button, Link, Grid, Typography, Container, List, ListItem, ListItemText, ListItemSecondaryAction, FormControl, InputLabel, MenuItem, Select, Collapse} from '@mui/material';
-import { ThemeProvider } from '@mui/material/styles';
-import { title, plan, brownTheme } from "@/styles/jss/animal-cloud-adoption.js";
-import EditIcon from '@mui/icons-material/Edit';
-
-// GET 所有方案所有資訊 
-const options = [
-  { id: 1, label: '方案一', price: 100, duration: 1 },
-  { id: 2, label: '方案二', price: 270, duration: 3 },
-  { id: 3, label: '方案三', price: 550, duration: 6 },
-  { id: 4, label: '方案四', price: 1000, duration: 12 },
-];
-
-// GET 單一 User (所有)資訊
-const user = { id: 33, email: 'b08705037@ntu.edu.tw', anonymous: true};
-
-// GET 單一 Animal (所有)資訊
-const animal = { id: 22, name: '小黑'};
+import React, { useEffect, useState } from "react";
+import Layout from "@/components/Layout";
+import JoinPlan from "@/components/PlanPage/JoinPlan";
+import { isLoggedIn } from "@/services/auth";
+import LoginRequest from "@/components/AuthPage/LoginRequest";
 
 export default function joinAdopt() {
-  // 選擇方案
-  const [selectedOption, setSelectedOption] = useState(null);
-  const [checked, setChecked] = React.useState(false);
-  const handleChange = (event) => {
-      setSelectedOption(event.target.value);
-      if (!selectedOption){
-        setChecked((prev) => !prev);
-      }
-  };
+  const [isClient, setIsClient] = useState(false);
 
-  const handleSubmit = (event) => {
-    event.preventDefault();
-    const data = new FormData(event.currentTarget);
-    const plan = selectedOption;
-    
-    if (!selectedOption) {
-    // 使用者沒有選擇方案，發出警告 Alert
-    alert('請選擇方案！');
-    } else {
-    // 寄發email
-    alert('匯款通知信件已寄出！\n請至您的 email 確認信件，\n並於時間內完成匯款。');
-
-    // 計算方案起訖日期
-    const today = new Date();
-    const currentDate = today.toLocaleDateString();
-    const futureDate = new Date(today.getFullYear(), today.getMonth() + plan.duration, today.getDate());
-    const endDate = futureDate.toLocaleDateString();
-
-    // 回傳
-    console.log({
-        amount: plan.price,
-        donatePeriod: plan.duration,
-        startDate: currentDate,
-        endDate: endDate,
-        planId: plan.id,
-        accountId: user.id,
-        animalId: animal.id,
-    });
-
-    // 導向動物資訊頁面
-    window.location.href = '/animals/animalsInfo';
-    }
-  };
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
 
   return (
-    <Layout>
-        <ThemeProvider theme={brownTheme}>
-          <div style={plan}>
-              <Container component="main" maxWidth="xs">
-                  <Box
-                  sx={{
-                      marginTop: 8,
-                      alignItems: 'center',
-                      marginBottom: 8
-                  }}
-                  >
-                  <h2 style={title}>
-                      加入{animal.name}的認養計畫！
-                  </h2>
-                    <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
-                        <List container spacing={2}>
-                            <ListItem>
-                                <ListItemText primary="帳號："/>
-                                <ListItemSecondaryAction>
-                                    {user.id}
-                                </ListItemSecondaryAction>
-                            </ListItem>
-                            <ListItem>
-                                <ListItemText primary="認養動物收容編號："/>
-                                <ListItemSecondaryAction>
-                                    {animal.id}
-                                </ListItemSecondaryAction>
-                            </ListItem>
-                            <ListItem>
-                                <ListItemText primary="捐款方式："/>
-                                <ListItemSecondaryAction>
-                                    <div>
-                                      {user.anonymous ? (
-                                        <>匿名捐款 <Link href="/account/edit"><EditIcon sx={{ fontSize:14 }} /></Link></>
-                                      ) : (
-                                        <>具名捐款 <Link href="/account/edit"><EditIcon sx={{ fontSize:14 }} /></Link></>
-                                      )}
-                                    </div>
-                                </ListItemSecondaryAction>
-                            </ListItem>
-                            <ListItem>
-                                <ListItemText primary="認養方案："/>
-                                <ListItemSecondaryAction>
-                                <FormControl sx={{minWidth: 100 }}>
-                                    <InputLabel id="option-label">方案</InputLabel>
-                                    <Select
-                                    labelId="option-label"
-                                    id="option"
-                                    value={selectedOption}
-                                    label="Option"
-                                    onChange={handleChange}
-                                    required
-                                    >
-                                    {options.map((option) => (
-                                        <MenuItem key={option.id} value={option}>
-                                        {option.label}
-                                        </MenuItem>
-                                    ))}
-                                    </Select>
-                                </FormControl>
-                                </ListItemSecondaryAction>
-                            </ListItem>
-                            <Collapse in={checked}>
-                              <ListItem sx={{ display: 'flex', justifyContent: 'center' }}>
-                              <Typography sx={{ m: 1, border: '1px solid gray', padding: '1rem', display: selectedOption ? 'block' : 'none' }} borderRadius="10px">
-                                  認養金額: ${selectedOption ? selectedOption.price : 'none'}
-                                  <br/>
-                                  認養時長: {selectedOption ? selectedOption.duration : 'none'} 個月
-                              </Typography>
-                              </ListItem>
-                            </Collapse>
-                        </List>
-                        <Button
-                        type="submit"
-                        fullWidth
-                        variant="contained"
-                        sx={{ mt: 2, mb: 2 }}
-                        >
-                        加入認養計畫
-                        </Button>
-                        <Grid container justifyContent="center" sx={{ mt: 1 }}>
-                          <Grid item sx={{ textAlign: 'center' }}>
-                              點擊「加入認養計畫」後，<br />
-                              我們會將匯款資訊寄送至您的信箱，<br />
-                              請於 3 天內完成匯款。<br />
-                              等待審查完畢後，即可成功認養{animal.name}！<br />
-                          </Grid>
-                          <Grid item sx={{ textAlign: 'center', mt: 1 }}>
-                            <Link href="/faq">
-                              進一步了解認養流程
-                            </Link>
-                          </Grid>
-                        </Grid>
-                    </Box>
-                  </Box>
-              </Container>
-            </div>
-        </ThemeProvider>
-    </Layout>
-  )
+    <div>
+      <Layout>
+        {isClient && (
+          <>
+            {isLoggedIn() ? (
+              <JoinPlan />
+            ) : (
+              <LoginRequest/>
+            )}
+          </>
+        )}
+      </Layout>
+    </div>
+  );
 }

--- a/frontend/services/auth.jsx
+++ b/frontend/services/auth.jsx
@@ -1,0 +1,38 @@
+// 判斷是否藉由瀏覽器瀏覽
+export const isBrowser = () => typeof window !== "undefined"
+
+// 從 LocalStorage 中取得使用者資訊，有的話就 Parse 這筆資訊。
+export const getUser = () =>
+  isBrowser() && window.localStorage.getItem("gatsbyUser")
+    ? JSON.parse(window.localStorage.getItem("gatsbyUser"))
+    : {}
+
+// 用來登入成功後，設定資訊在 LocalStorage 中。
+const setUser = user =>
+  window.localStorage.setItem("gatsbyUser", JSON.stringify(user))
+
+
+// 處理登入，這邊使用 Hard Code 的方式驗證，此方式極度不安全，只是為了示範登入流程才用此方式，正式環境上會打 API 去跟後端確認資料是否正確，並等回傳結果後才會進行下一步
+export const handleLogin = ({ username, password }) => {
+  if (username === `ithelp` && password === `123456`) {
+    return setUser({
+      username: `reynold`,
+      name: `Reynold`,
+      email: `reynold@example.org`,
+    })
+  }
+
+  return false
+}
+
+// 判斷使用者是否已經登入，如以登入就直接從 LocalStorage 中撈取使用者資料
+export const isLoggedIn = () => {
+  const user = getUser()
+
+  return !!user.username
+}
+
+// 登出，直接將使用者資料清空
+export const logout = () => {
+  setUser({})
+}

--- a/frontend/services/auth.jsx
+++ b/frontend/services/auth.jsx
@@ -14,11 +14,11 @@ const setUser = user =>
 
 // 處理登入，這邊使用 Hard Code 的方式驗證，此方式極度不安全，只是為了示範登入流程才用此方式，正式環境上會打 API 去跟後端確認資料是否正確，並等回傳結果後才會進行下一步
 export const handleLogin = ({ username, password }) => {
-  if (username === `ithelp` && password === `123456`) {
+  if (username === `test` && password === `123456`) {
+    // 存在前端的資訊，可以視情況新增
     return setUser({
-      username: `reynold`,
-      name: `Reynold`,
-      email: `reynold@example.org`,
+      id: 1,
+      username: `test`,
     })
   }
 


### PR DESCRIPTION
更新內容：
- 新增 services/auth/jsx，包含用戶驗證相關的各種功能，主要包含：
 1. 從 LocalStorage 中取得使用者的 id 和 username(註一)
 2. 處理登入(註二)
 3. 處理登出(註三)
 4. 判斷使用者是否已經登入
-  新增 JoinPlan, ExtendPlan 的 components，是將原本 joinAdopt, extendAdopt 等 pages 的內容包在 component 裡
-  變更 joinAdopt, extendAdopt 的渲染方式(註四)
- README

註一：任何需要使用者 id 的頁面、API，可以用 getUser().id 的函數拿到
註二：這邊先使用 Hard Code 的方式驗證，後端需再確認資料是否正確
註三：需依照使用者是否登入在 header 新增登出/登入按鈕
註四：任何需要登入才能訪問的頁面需要依循這兩個頁面的渲染方式做更改（這邊的條件渲染應該可以用私人路由來取代，但我一直沒寫成功qq）